### PR TITLE
Reaction paginator optimisation

### DIFF
--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -185,9 +185,9 @@ async def paginate(bot, ctx, title, message_list, page_start=0, page_end=10, pag
             sent_message = await ctx.send(embed=embed)
         else:
             try:
-                await sent_message.clear_reactions()
+                await reaction.remove(user)
             except (discord.ext.commands.errors.CommandInvokeError, discord.errors.Forbidden):
-                logger.warn('Unable to clear message reaction due to insufficient permissions. Giving bot \'Manage Messages\' permission will improve usability.')
+                logger.warn('Unable to remove message reaction due to insufficient permissions. Giving bot \'Manage Messages\' permission will improve usability.')
             await sent_message.edit(embed=embed)
 
         if page_start > 0:


### PR DESCRIPTION
Only remove reactions as necessary in order to increase ease of scrolling and reduce chance of ratelimiting. Sorry I don't have testing set up but this should work fine.