### PR TITLE
Add app authentication to the API.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -202,7 +202,11 @@ def init_bot(loop: asyncio.AbstractEventLoop = None, args: list[str] = None):
         utilities.connect()
         logger.debug(f'Command invoked: {ctx.message.clean_content}. By {ctx.message.author.name} in {ctx.channel.id} {ctx.channel.name} on {ctx.guild.name}')
 
-    initial_extensions = ['modules.games', 'modules.customhelp', 'modules.matchmaking', 'modules.administration', 'modules.misc', 'modules.league']
+    initial_extensions = [
+        'modules.games', 'modules.customhelp', 'modules.matchmaking',
+        'modules.administration', 'modules.misc', 'modules.league',
+        'modules.api_cog'
+    ]
     for extension in initial_extensions:
         bot.load_extension(extension)
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -1,27 +1,54 @@
 """Read-only HTTP API for bot data."""
-import fastapi
+from fastapi import Depends, FastAPI, HTTPException, Response
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
-from .models import DiscordMember, Game
+from .models import ApiApplication, DiscordMember, Game
 
 
-server = fastapi.FastAPI()
+server = FastAPI()
+security = HTTPBasic()
+
+
+async def get_scopes(
+        credentials: HTTPBasicCredentials = Depends(security)) -> list[str]:
+    """Get the scopes the requester has access to."""
+    app = ApiApplication.authenticate(
+        credentials.username, credentials.password
+    )
+    if app:
+        return app.scopes.split()
+    raise HTTPException(
+        status_code=401,
+        detail='Incorrect app ID or token.',
+        headers={'WWW-Authenticate': 'Basic'}
+    )
 
 
 @server.get('/users/{discord_id}')
-async def get_user(discord_id: int, response: fastapi.Response) -> dict:
+async def get_user(
+        discord_id: int, response: Response,
+        scopes: list[str] = Depends(get_scopes)) -> dict:
     """Get a user by discord ID."""
+    if 'users:read' not in scopes:
+        raise HTTPException(
+            status_code=403, detail='Not authorised for scope users:read.'
+        )
     user = DiscordMember.get_or_none(DiscordMember.discord_id == discord_id)
     if user:
-        return user.as_json()
-    response.status_code = 404
-    return {'error': 'User not found.'}
+        return user.as_json(include_games='games:read' in scopes)
+    raise HTTPException(status_code=404, detail='User not found.')
 
 
 @server.get('/games/{game_id}')
-async def get_game(game_id: int, response: fastapi.Response) -> dict:
+async def get_game(
+        game_id: int, response: Response,
+        scopes: list[str] = Depends(get_scopes)) -> dict:
     """Get a game by ID."""
+    if 'games:read' not in scopes:
+        raise HTTPException(
+            status_code=403, detail='Not authorised for scope games:read.'
+        )
     game = Game.get_or_none(Game.id == game_id)
     if game:
         return game.as_json()
-    response.status_code = 404
-    return {'error': 'Game not found.'}
+    raise HTTPException(status_code=404, detail='Game not found.')

--- a/modules/api_cog.py
+++ b/modules/api_cog.py
@@ -1,0 +1,142 @@
+"""Discord.py extension for managing API applications."""
+import discord
+from discord.ext import commands
+
+from . import models
+
+
+class Api(commands.Cog, name='api'):
+    """Commands for viewing and managing your API apps."""
+
+    def __init__(self, bot: commands.Bot):
+        """Store a reference to the bot."""
+        self.bot = bot
+
+    @commands.is_owner()
+    @commands.command(name='add-application', aliases=['add-app'])
+    async def add_application(
+            self, ctx: commands.Context, owner: discord.User, *, name: str):
+        """Authorise a new application to use the API.
+
+        `owner` is the person who will be able to manage the application
+        (ie. get and reset its token).
+
+        Example: `[p]add-app @Legorooj Awesome Bot 3000`
+        """
+        owner_member = models.DiscordMember.get_or_none(
+            models.DiscordMember.discord_id == owner.id
+        )
+        if not owner_member:
+            owner_member = models.DiscordMember.create(
+                discord_id=owner.id, name=owner.name
+            )
+        app = models.ApiApplication.create(owner=owner_member, name=name)
+        app.generate_new_token()
+        await ctx.send(
+            f'Created app **{name}** for **{owner.display_name}**.'
+        )
+
+    @commands.is_owner()
+    @commands.command(name='all-applications', aliases=['all-apps'])
+    async def all_applications(self, ctx: commands.Context):
+        """Get a list of every app, its scopes, ID, name and owner.
+
+        Example: `[p]all-apps`
+        """
+        embed = discord.Embed(title='API Apps')
+        for app in models.ApiApplication.select().join(models.DiscordMember):
+            embed.add_field(
+                name=app.name,
+                value=(
+                    f'`{app.id:>2}` owned by '
+                    f'<@{app.owner.discord_id}> ({app.owner.name})\n\n'
+                    f'`{app.scopes}`'
+                ),
+                inline=False
+            )
+        await ctx.send(embed=embed)
+
+    @commands.is_owner()
+    @commands.command(name='delete-application', aliases=['del-app'])
+    async def delete_application(
+            self, ctx: commands.Context, app: models.ApiApplication):
+        """Delete an application by ID.
+
+        Example: `[p]del-app 5`
+        """
+        name = app.name
+        app.delete_instance()
+        await ctx.send(f'Deleted app **{name}**.')
+
+    @commands.is_owner()
+    @commands.command(name='authorise-application', aliases=['auth-app'])
+    async def authorise_application(
+            self, ctx: commands.Context,
+            app: models.ApiApplication, *, scopes: str):
+        """Authorise an application to use certain scopes.
+
+        Example: `[p]auth-app 2 users:read games:read`
+
+        Note that this also removes any scopes the app previously had access
+        to - you must specify them all in the same command.
+        """
+        app.scopes = scopes
+        app.save()
+        await ctx.send(f'Updated scopes for **{app.name}**.')
+
+    @commands.command(brief='View your apps.')
+    async def apps(self, ctx: commands.Context):
+        """View all API apps you own.
+
+        Example: `[p]apps`
+        """
+        member = models.DiscordMember.get_or_none(
+            ctx.author.id == models.DiscordMember.discord_id
+        )
+        if not member:
+            await ctx.send('You are not registered with the bot.')
+            return
+        lines = ['You have the following apps:']
+        for app in member.applications:
+            lines.append(f'`{app.id:>2}` **{app.name}**\n`{app.scopes}`')
+        await ctx.send('\n\n'.join(lines))
+
+    @commands.command(brief='Get your app\'s token.', name='app-token')
+    async def app_token(
+            self, ctx: commands.Context, *, app: models.ApiApplication):
+        """Get the token of an app you own (it will be DMed to you).
+
+        You must specify the app by its ID.
+
+        Example: `[p]app-token 3`
+        """
+        if app.owner.discord_id != ctx.author.id:
+            await ctx.send('You don\'t own that app!')
+            return
+        await ctx.author.send(
+            f'Username: `{app.id}`\n'
+            f'Password: `{app.token}`\n'
+            f'Authorization: `Basic {app.user_pass}`\n'
+            f'Scopes: `{app.scopes}`'
+        )
+        await ctx.send('DMed you.')
+
+    @commands.command(brief='Reset your app\'s token.', name='reset-token')
+    async def reset_token(
+            self, ctx: commands.Context, *, app: models.ApiApplication):
+        """Reset the token of an app you own.
+
+        You must specify the app by its ID.
+
+        Example: `[p]app-token 5`
+        """
+        if app.owner.discord_id != ctx.author.id:
+            await ctx.send('You don\'t own that app!')
+            return
+        app.generate_new_token()
+        await ctx.send(f'Reset token for **{app.name}**!')
+
+
+def setup(bot: commands.Bot):
+    """Add the cog to a bot."""
+    bot.add_cog(Api(bot))


### PR DESCRIPTION
 - Bot owner manages apps with the `add-app`, `del-app` and `auth-app` commands.
 - App owners manage/view their apps with `app-token`, `reset-token` and `apps`.
 - Apps have an ID and token which are passed to the API with basic HTTP authentication.
 - Apps also have a list of scopes granted by the bot owner with `auth-app`.
 - Currently, supported scopes are `users:read` and `games:read`.