### PR TITLE
Fixed bug with players' cards during draft if the avatar is default

### DIFF
--- a/modules/imgen.py
+++ b/modules/imgen.py
@@ -155,7 +155,7 @@ def player_draft_card(
     title = f'{selecting_string.upper()} SELECT'
     player_avatar = fetch_image(str(member.avatar_url_as(
         format='png', size=256
-    )))
+    ))).convert("RGB")
     name = member.name.upper()
     summary = get_player_summary(member)
     wordmark = Image.open('res/pc_wordmark.png')

--- a/modules/imgen.py
+++ b/modules/imgen.py
@@ -155,7 +155,9 @@ def player_draft_card(
     title = f'{selecting_string.upper()} SELECT'
     player_avatar = fetch_image(str(member.avatar_url_as(
         format='png', size=256
-    ))).convert("RGB")
+    )))
+    if not member.avatar:
+        player_avatar = player_avatar.convert("RGB")
     name = member.name.upper()
     summary = get_player_summary(member)
     wordmark = Image.open('res/pc_wordmark.png')

--- a/modules/models.py
+++ b/modules/models.py
@@ -2131,7 +2131,7 @@ class Game(BaseModel):
 
         if title_filter:
 
-            strip_regexp = re.compile('[^1-9a-zA-Z ]')  # strip out everything except alphanumerics and spaces
+            strip_regexp = re.compile('[^0-9a-zA-Z ]')  # strip out everything except alphanumerics and spaces
             clean_search_terms = strip_regexp.sub('', ' '.join(title_filter)).split()
             search_regexp = '^' + ''.join([f'(?=.*{arg})' for arg in clean_search_terms]) + '.+'
             # https://stackoverflow.com/questions/24656131/regex-for-existence-of-some-words-whose-order-doesnt-matter


### PR DESCRIPTION
Added RGB conversion for the player's avatars so they are not conflicting with background like it was before with default avatars. Transparent parts of the avatars are now black because simple RGB does not support transparency.
![The_Ronin_selects_Illya](https://user-images.githubusercontent.com/40856235/126150071-4315bb76-e5e8-4a6e-a9df-897334eff735.png)
![The_Ronin_selects_Illya2](https://user-images.githubusercontent.com/40856235/126150078-72fcb537-4882-4ccd-8819-2e2c7470ebab.png)
