### PR TITLE
Fixed issue with draft cards and default avatatars

### DIFF
--- a/modules/imgen.py
+++ b/modules/imgen.py
@@ -155,7 +155,7 @@ def player_draft_card(
     title = f'{selecting_string.upper()} SELECT'
     player_avatar = fetch_image(str(member.avatar_url_as(
         format='png', size=256
-    )))
+    ))).convert("RGB")
     name = member.name.upper()
     summary = get_player_summary(member)
     wordmark = Image.open('res/pc_wordmark.png')

--- a/modules/imgen.py
+++ b/modules/imgen.py
@@ -155,7 +155,9 @@ def player_draft_card(
     title = f'{selecting_string.upper()} SELECT'
     player_avatar = fetch_image(str(member.avatar_url_as(
         format='png', size=256
-    ))).convert("RGB")
+    )))
+    if not member.avatar:
+        player_avatar = player_avatar.convert("RGB")
     name = member.name.upper()
     summary = get_player_summary(member)
     wordmark = Image.open('res/pc_wordmark.png')

--- a/modules/models.py
+++ b/modules/models.py
@@ -2131,7 +2131,7 @@ class Game(BaseModel):
 
         if title_filter:
 
-            strip_regexp = re.compile('[^1-9a-zA-Z ]')  # strip out everything except alphanumerics and spaces
+            strip_regexp = re.compile('[^0-9a-zA-Z ]')  # strip out everything except alphanumerics and spaces
             clean_search_terms = strip_regexp.sub('', ' '.join(title_filter)).split()
             search_regexp = '^' + ''.join([f'(?=.*{arg})' for arg in clean_search_terms]) + '.+'
             # https://stackoverflow.com/questions/24656131/regex-for-existence-of-some-words-whose-order-doesnt-matter


### PR DESCRIPTION
If the avatar is default (they cause value error with transparency mask), it's converted to RGB format to be compatible with all the other image
![The_Ronin_selects_Illya](https://user-images.githubusercontent.com/40856235/126152831-9a1123bd-0bd3-4502-9239-cd3f452347ca.png)
![The_Ronin_selects_Illya2](https://user-images.githubusercontent.com/40856235/126152836-ac71276f-65ad-4d81-bfc3-dad86c864999.png)
