### PR TITLE
Promote command partially fixed

### DIFF
--- a/modules/league.py
+++ b/modules/league.py
@@ -799,7 +799,7 @@ class league(commands.Cog):
                     guild_matches = await utilities.get_guild_member(ctx, image_arg)
                     if len(guild_matches) == 1:
                         # passed member mention. use profile picture/avatar
-                        return guild_matches[0].display_avatar.replace(size=512, format='webp'), \
+                        return guild_matches[0].display_avatar.replace(size=512), \
                             '#00ff00' if position == 0 else '#ff0000'
                     else:
                         raise ValueError(f'Cannot convert *{image_arg}* to an image.')


### PR DESCRIPTION
- guild members avatars are no longer forced into .webp, which resulted in them not being fetchable