### PR TITLE
Fix generic team category search logic

### DIFF
--- a/modules/channels.py
+++ b/modules/channels.py
@@ -45,25 +45,27 @@ def get_channel_category(guild, team_name: str = None, using_team_server_flag: b
 
     if team_name:
         team_name_lc = team_name.lower().replace('the', '').strip()  # The Ronin > ronin
+        team_is_generic = team_name in list_of_generic_team_names
         # first seek a category named something like 'Polychamps Ronin Games', fallback to any category with 'Ronin' in the name.
         # TODO: perm check in each fall back condition to make sure bot actually has permissions
-        for cat in guild.categories:
-            logger.debug(f'1 Checking category {cat.name}')
-            if 'polychamp' in cat.name.lower() and team_name_lc in cat.name.lower():
-                logger.debug(f'Using {cat.id} - {cat.name} as a team channel category')
-                if len(cat.channels) >= 50:
-                    logger.warning('Chosen category is full - falling back')
-                    continue
-                return cat, True
-        for cat in guild.categories:
-            logger.debug(f'2 Checking category {cat.name}')
-            if team_name_lc in cat.name.lower():
-                logger.debug(f'Using {cat.id} - {cat.name} as a team channel category')
-                if len(cat.channels) >= 50:
-                    logger.warning('Chosen category is full - falling back')
-                    continue
-                return cat, True
-        if team_name in list_of_generic_team_names and using_team_server_flag:
+        if not team_is_generic:
+            for cat in guild.categories:
+                logger.debug(f'1 Checking category {cat.name}')
+                if 'polychamp' in cat.name.lower() and team_name_lc in cat.name.lower():
+                    logger.debug(f'Using {cat.id} - {cat.name} as a team channel category')
+                    if len(cat.channels) >= 50:
+                        logger.warning('Chosen category is full - falling back')
+                        continue
+                    return cat, True
+            for cat in guild.categories:
+                logger.debug(f'2 Checking category {cat.name}')
+                if team_name_lc in cat.name.lower():
+                    logger.debug(f'Using {cat.id} - {cat.name} as a team channel category')
+                    if len(cat.channels) >= 50:
+                        logger.warning('Chosen category is full - falling back')
+                        continue
+                    return cat, True
+        if team_is_generic and using_team_server_flag:
             for cat in guild.categories:
                 logger.debug(f'3 Checking category {cat.name}')
                 if 'polychamp' in cat.name.lower() and 'other' in cat.name.lower():


### PR DESCRIPTION
## Summary
- avoid treating generic team names as substrings when searching for team-specific categories in `get_channel_category`

## Testing
- `python -m py_compile modules/channels.py`

------
https://chatgpt.com/codex/tasks/task_e_686e82ad9eac832eaa3100bbf6365aca