### PR TITLE
Harden backups and record Python/PostgreSQL cutovers

### DIFF
--- a/docs/POSTGRESQL_UPGRADE_PLAN.md
+++ b/docs/POSTGRESQL_UPGRADE_PLAN.md
@@ -270,9 +270,10 @@ Post-upgrade verification confirmed:
   `polytopia.service` retained PID 1480385 with zero restarts.
 
 The rehearsal temporarily raised root-filesystem use to 91%, with
-approximately 2.0 GiB free. The stopped PostgreSQL 12 rehearsal cluster,
-online PostgreSQL 18 rehearsal cluster, and private rehearsal archives remain
-pending separately approved cleanup.
+approximately 2.0 GiB free. After separate approval, `18/rehearsal18`,
+`12/rehearsal`, and `/var/lib/postgresql/rehearsal-backups` were removed.
+Only production `12/main` remained, and free space returned to approximately
+4.1 GiB.
 
 The rehearsed production command is equivalent to:
 
@@ -281,10 +282,10 @@ pg_upgradecluster --method=upgrade --jobs=2 -v 18 12 main
 ```
 
 The rehearsal proved its port, configuration-copy, old-cluster retention, and
-rollback behavior. Executing it against production still requires completion
-of PG4 and separate maintenance-window approval for PG5.
+rollback behavior. Executing it against production still requires separate
+maintenance-window approval for PG5.
 
-## Phase PG4: pre-cutover backup set
+## Phase PG4 completed: pre-cutover backup set
 
 The normal `/home/nelluk/backup_db.sh` protects `polytopia2` and local images,
 but it is not a complete cluster backup. It omits global roles and the other
@@ -306,14 +307,46 @@ Before the maintenance window:
 Using the newer dump programs is consistent with PostgreSQL's recommendation
 for major-version dump/restore planning.
 
+Nelluk separately approved PG4. On 2026-07-28:
+
+- `/home/nelluk/backup_db.sh` completed successfully using its hardened,
+  locked, atomic workflow.
+- A private timestamped archive was created at
+  `/home/nelluk/backups/postgresql18-pg4-20260728T214311-0400`.
+- The archive directory is mode 0700 and every contained file is mode 0600.
+- PostgreSQL 18 client tools created a globals-only dump and custom-format
+  dumps of `polytopia2`, `polytopia_dev`, and `twospies` from the online
+  PostgreSQL 12 server.
+- The online `polytopia2` dump completed in approximately 21 seconds.
+- Every custom-format dump passed PostgreSQL 18
+  `pg_restore --list`.
+- The archive records installed package versions, clusters, role flags,
+  database ownership/encoding/locale/size, sessions, listeners, service
+  states, data checksums, extensions, representative row counts, invalid
+  indexes, and checksums of the normal bot-backup artifacts.
+- `postgresql-config.tar.gz` contains `/etc/postgresql/12/main` and
+  `/etc/postgresql-common`, including the production HBA policy and
+  `pg_upgradecluster.d/analyze` hook.
+- `SHA256SUMS` validates every file in the archive.
+- The completed archive is approximately 115 MB.
+- Production remained on PostgreSQL 12, localhost-only, with
+  `polytopia.service` retaining PID 1480385 and zero restarts.
+- Approximately 4.0 GiB remained free after PG4.
+
+PG4 did not stop or restart PostgreSQL or the bot. Its online dumps are the
+pre-cutover recovery layer; PG5 still requires a final stopped-service backup
+immediately before the production upgrade.
+
 ## Phase PG5: maintenance-window cutover
 
 1. Confirm the bot is healthy and `polyapi.service` is inactive.
 2. Stop `polytopia.service`.
 3. Confirm no application sessions remain.
 4. Take and validate a final stopped-service cluster-wide logical backup.
-5. Stop PostgreSQL 12 and the empty PostgreSQL 18 destination.
-6. Run the rehearsed copy-mode cluster upgrade as `postgres`.
+5. Confirm no `18/main` target cluster exists.
+6. Run the rehearsed copy-mode cluster upgrade as root. The wrapper stops
+   PostgreSQL 12, creates `18/main`, performs `pg_upgrade`, moves the old
+   PostgreSQL 12 cluster to a nonproduction port, and starts PostgreSQL 18.
 7. Confirm the wrapper assigns PostgreSQL 18 the production port 5432 and
    leaves PostgreSQL 12 stopped, independent, and in manual startup mode on a
    nonproduction port.

--- a/docs/POSTGRESQL_UPGRADE_PLAN.md
+++ b/docs/POSTGRESQL_UPGRADE_PLAN.md
@@ -337,7 +337,7 @@ PG4 did not stop or restart PostgreSQL or the bot. Its online dumps are the
 pre-cutover recovery layer; PG5 still requires a final stopped-service backup
 immediately before the production upgrade.
 
-## Phase PG5: maintenance-window cutover
+## Phase PG5 completed: maintenance-window cutover
 
 1. Confirm the bot is healthy and `polyapi.service` is inactive.
 2. Stop `polytopia.service`.
@@ -369,6 +369,59 @@ immediately before the production upgrade.
     access, guilds, Bullet loading, and read-only commands.
 15. Replace the canary command with the permanent systemd drop-in, restart the
     bot with tasks enabled, and observe both services for at least ten minutes.
+
+Nelluk separately approved the production maintenance window. On 2026-07-29:
+
+- The refreshed disk audit reported 4.3 GiB free and no failed units.
+- The PG4 archive and current normal backup were revalidated.
+- `polytopia.service` was stopped cleanly, leaving no application process or
+  database session.
+- The hardened normal backup completed while the bot was stopped.
+- A final private cluster-wide backup was created at
+  `/home/nelluk/backups/postgresql18-final-stopped-20260729T065335-0400`.
+  It contains PostgreSQL 18-client globals and custom-format dumps for all
+  three application databases, the pre-upgrade PostgreSQL configuration,
+  integrity metadata, and a validated `SHA256SUMS` manifest. The archive is
+  approximately 115 MB, with a mode-0700 directory and mode-0600 files.
+- With no `18/main` target present, production was upgraded using:
+
+  ```bash
+  sudo pg_upgradecluster \
+    --method=upgrade \
+    --jobs=2 \
+    -v 18 \
+    12 main
+  ```
+
+- The full copy-mode upgrade and finish hooks completed in approximately
+  25 seconds. PostgreSQL 18.4 started on port 5432; PostgreSQL 12 was retained
+  stopped and in manual mode on port 5433.
+- The PostgreSQL 12 and 18 HBA files matched exactly. The new cluster retained
+  localhost-only listening and the `polybot_dev` rejection from `polytopia2`.
+- Database owners, roles, encoding, locale, data-checksum state, extensions,
+  schema objects, every high-value row count, and all collation versions
+  matched the final stopped-service snapshot. No index was invalid.
+- All 54 Python 3.12 tests passed against migrated `polytopia_dev` on
+  PostgreSQL 18. `polybot_dev` could connect to `polytopia_dev` and was
+  rejected from `polytopia2`.
+- A task-disabled production bot canary connected to PostgreSQL 18 and Discord,
+  loaded every production guild, and passed Nelluk's read-only command smoke
+  tests with zero restarts and no scheduled background loop.
+- Startup reasserted the existing ban flags with idempotent `UPDATE`
+  statements. Consequently, rollback after the canary must be treated as
+  potentially lossy even though representative row counts remained unchanged.
+- The temporary canary drop-in was removed. The permanent bot started without
+  `--skip_tasks`; matchmaking, league, and automatic-confirmation tasks ran
+  without error.
+- The bot and PostgreSQL 18 retained stable PIDs and zero restarts throughout
+  a sampled observation window exceeding ten minutes.
+- The first hardened production backup on PostgreSQL 18 completed and
+  validated. Its full custom archive records both source server and
+  `pg_dump` version 18.4.
+- The root filesystem retained approximately 3.2 GiB free after cutover.
+
+The old PostgreSQL 12 cluster and its packages were intentionally retained.
+Their removal is not part of the cutover approval.
 
 ## Rollback
 

--- a/docs/POSTGRESQL_UPGRADE_PLAN.md
+++ b/docs/POSTGRESQL_UPGRADE_PLAN.md
@@ -40,11 +40,13 @@ Clusters:
 | Version | Port | State | Purpose |
 | --- | ---: | --- | --- |
 | 12.20 | 5432 | online | active production and development data |
-| 14.23 | 5433 | online | apparently unused default Ubuntu cluster |
+| 14.23 | 5433 | online | verified unused default Ubuntu cluster |
 
-The PostgreSQL 14 cluster rejects local login as `nelluk` because that role
-does not exist there. Treat this only as strong evidence of an untouched
-default cluster; inspect it as `postgres` before approving its removal.
+The PostgreSQL 14 cluster was inspected as `postgres` on 2026-07-28. It
+contains only the connectable `postgres` and `template1` databases at about
+8.6 MB each, only built-in roles plus `postgres`, and no client session other
+than the inspection query. It also rejects local login as `nelluk` because
+that role does not exist. This confirms it is an unused default cluster.
 
 Databases in the PostgreSQL 12 cluster:
 
@@ -91,9 +93,9 @@ the migration mechanism, not the only backup.
 - Stop the bot before the final backup and cluster upgrade.
 - Start the bot against PostgreSQL 18 with background tasks disabled first.
 
-## Phase PG1: resolve the existing PostgreSQL 14 cluster
+## Phase PG1 completed: resolve the existing PostgreSQL 14 cluster
 
-Nelluk must inspect the port-5433 cluster as its owner:
+Nelluk inspected the port-5433 cluster as its owner with:
 
 ```bash
 sudo -u postgres psql -X -P pager=off -p 5433 -d postgres \
@@ -116,8 +118,8 @@ sudo -u postgres psql -X -P pager=off -p 5433 -d postgres \
       ORDER BY datname, usename;"
 ```
 
-If and only if it contains only default databases/roles and no client, request
-separate approval to remove it:
+The output confirmed only default databases/roles and no client. Its removal
+is still a separate destructive approval:
 
 ```bash
 sudo pg_dropcluster --stop 14 main

--- a/docs/POSTGRESQL_UPGRADE_PLAN.md
+++ b/docs/POSTGRESQL_UPGRADE_PLAN.md
@@ -1,0 +1,298 @@
+# PostgreSQL 12 to 18 upgrade plan
+
+This document plans a PostgreSQL server upgrade for `racknerd`. It does not
+authorize package installation, cluster creation/removal, a PostgreSQL
+restart, a database restore, or a production-bot restart.
+
+## Recommendation
+
+Upgrade the complete PostgreSQL 12 cluster directly to PostgreSQL 18 by using
+`pg_upgrade` in copy mode through Ubuntu's `pg_upgradecluster` wrapper. Rehearse
+the exact wrapper command against a disposable PostgreSQL 18 cluster first.
+
+Do not use the already-installed PostgreSQL 14 cluster as the destination.
+PostgreSQL 14 reaches end of community support on 2026-11-12, while PostgreSQL
+18 is supported through 2030-11-14. PostgreSQL 12 has been unsupported since
+2024-11-21.
+
+Primary references:
+
+- [PostgreSQL versioning policy](https://www.postgresql.org/support/versioning/)
+- [PostgreSQL 18 `pg_upgrade`](https://www.postgresql.org/docs/current/pgupgrade.html)
+- [PostgreSQL cluster-upgrade methods](https://www.postgresql.org/docs/current/upgrading.html)
+- [Official PostgreSQL Ubuntu packages](https://www.postgresql.org/download/linux/ubuntu/)
+
+## Observed host and cluster state
+
+Recorded on 2026-07-28:
+
+- Ubuntu 22.04.5 LTS (`jammy`), x86-64, ext4
+- 2 vCPUs, 2.3 GiB RAM, 2.4 GiB swap
+- approximately 4.3 GiB free on `/`
+- no standby, replication node, tablespace, publication, replication slot,
+  prepared transaction, or large object
+- PostgreSQL listens only on localhost
+- data checksums are disabled on the PostgreSQL 12 cluster
+- only the built-in `plpgsql` extension is installed in `polytopia2`
+
+Clusters:
+
+| Version | Port | State | Purpose |
+| --- | ---: | --- | --- |
+| 12.20 | 5432 | online | active production and development data |
+| 14.23 | 5433 | online | apparently unused default Ubuntu cluster |
+
+The PostgreSQL 14 cluster rejects local login as `nelluk` because that role
+does not exist there. Treat this only as strong evidence of an untouched
+default cluster; inspect it as `postgres` before approving its removal.
+
+Databases in the PostgreSQL 12 cluster:
+
+| Database | Owner | Approximate size | Observed use |
+| --- | --- | ---: | --- |
+| `polytopia2` | `nelluk` | 864 MB | production PolyBot |
+| `polytopia_dev` | `polybot_dev` | 9.3 MB | development PolyBot |
+| `twospies` | `nelluk` | 8.7 MB | no active session; old backup cron is commented |
+| `postgres` | `postgres` | 8.0 MB | administration |
+
+The plan preserves `twospies`. Its removal would be a separate destructive
+decision even if it is confirmed abandoned.
+
+The live application presented three idle local sessions to `polytopia2`.
+There was no active session to `twospies` or `polytopia_dev` during inspection.
+
+## Why copy-mode `pg_upgrade`
+
+PostgreSQL documents that `pg_upgrade` supports upgrades from 9.2 and later
+directly to the current release. Copy mode is preferred here because:
+
+- the cluster is small enough to duplicate with the available disk space;
+- it leaves the PostgreSQL 12 data directory independent and restartable;
+- it avoids link mode's restriction that the old cluster becomes unsafe after
+  the new cluster writes shared files;
+- ext4 does not provide the supported reflink/clone behavior described for
+  Btrfs, XFS with reflinks, or APFS;
+- it should cause substantially less downtime than a full logical
+  dump-and-restore migration.
+
+Logical dumps remain the portable recovery source. Copy-mode `pg_upgrade` is
+the migration mechanism, not the only backup.
+
+## Fixed safety boundaries
+
+- Upgrade the entire cluster, including roles and every database.
+- Keep PostgreSQL local-only.
+- Preserve the `polybot_dev` rejection rules for `polytopia2`.
+- Do not enable `polyapi.service`.
+- Do not change application schema or bot dependency versions in this work.
+- Do not use `--link`, `--clone`, `--swap`, or `--no-sync`.
+- Do not delete PostgreSQL 12 until a settling period has passed.
+- Do not restore over a live database without separate approval.
+- Stop the bot before the final backup and cluster upgrade.
+- Start the bot against PostgreSQL 18 with background tasks disabled first.
+
+## Phase PG1: resolve the existing PostgreSQL 14 cluster
+
+Nelluk must inspect the port-5433 cluster as its owner:
+
+```bash
+sudo -u postgres psql -X -P pager=off -p 5433 -d postgres \
+  -c "SELECT version();"
+
+sudo -u postgres psql -X -P pager=off -p 5433 -d postgres \
+  -c "SELECT datname, pg_size_pretty(pg_database_size(datname))
+      FROM pg_database
+      WHERE datallowconn
+      ORDER BY datname;"
+
+sudo -u postgres psql -X -P pager=off -p 5433 -d postgres \
+  -c "SELECT rolname, rolsuper, rolcanlogin
+      FROM pg_roles
+      ORDER BY rolname;"
+
+sudo -u postgres psql -X -P pager=off -p 5433 -d postgres \
+  -c "SELECT datname, usename, application_name, client_addr, state
+      FROM pg_stat_activity
+      ORDER BY datname, usename;"
+```
+
+If and only if it contains only default databases/roles and no client, request
+separate approval to remove it:
+
+```bash
+sudo pg_dropcluster --stop 14 main
+```
+
+Do not remove the PostgreSQL 14 packages yet. The cluster removal and package
+cleanup are distinct actions.
+
+## Phase PG2: install PostgreSQL 18 without cutting over
+
+Ubuntu 22.04's distribution repository stops at PostgreSQL 14. Use the official
+PostgreSQL Apt repository, which supports `jammy` and publishes PostgreSQL 18.
+
+The official automated setup is:
+
+```bash
+sudo apt install -y postgresql-common
+sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+sudo apt update
+sudo apt install postgresql-18 postgresql-client-18
+```
+
+Before running it:
+
+- refresh and read the disk audit;
+- record the exact Apt transaction;
+- confirm no unrelated package removal;
+- expect `postgresql-common` and `libpq` package updates;
+- confirm whether installation will create/start `18/main`;
+- ensure PostgreSQL 12 remains on port 5432 throughout this phase.
+
+If package installation creates `18/main`, stop it until rehearsal:
+
+```bash
+sudo pg_ctlcluster 18 main stop
+pg_lsclusters
+```
+
+Package installation is a separately approved system change. It is not
+approval to upgrade the data cluster.
+
+## Phase PG3: rehearsal and compatibility proof
+
+Use a disposable PostgreSQL 18 cluster on a nonproduction port. Restore a
+logical production dump and test without Discord:
+
+1. Create a fresh PostgreSQL 18 test cluster on an unused port.
+2. Use PostgreSQL 18 client tools to dump from PostgreSQL 12.
+3. Restore `polytopia2` into the test cluster.
+4. Compare database ownership, encoding, locale, schema, table counts, and
+   representative row counts.
+5. Compare the largest/high-value tables:
+   `gamelog`, `lineup`, `gameside`, `game`, `player`, and `discordmember`.
+6. Run representative Peewee reads, writes inside rolled-back transactions,
+   graph rendering, and API route tests against PostgreSQL 18.
+7. Run the Python 3.12 application test suite.
+8. Run the exact `pg_upgrade --check`/`pg_upgradecluster` preflight intended for
+   production and preserve its output.
+9. Measure restore and upgrade duration to size the maintenance window.
+10. Remove only the disposable rehearsal cluster after its results are
+    reviewed and separately approved.
+
+The rehearsal will establish the exact `pg_upgradecluster` syntax delivered by
+the installed `postgresql-common` version. The anticipated production command
+is equivalent to:
+
+```text
+pg_upgradecluster --method=upgrade --jobs=2 -v 18 12 main
+```
+
+Do not execute that command against production until the rehearsal proves its
+port, configuration-copy, old-cluster retention, and rollback behavior.
+
+## Phase PG4: pre-cutover backup set
+
+The normal `/home/nelluk/backup_db.sh` protects `polytopia2` and local images,
+but it is not a complete cluster backup. It omits global roles and the other
+databases.
+
+Before the maintenance window:
+
+- run and validate the normal atomic bot backup;
+- create a private timestamped upgrade archive;
+- archive `/etc/postgresql/12/main`;
+- record package versions, clusters, role flags, database owners/sizes,
+  authentication rules, and active sessions;
+- create a globals-only dump with the PostgreSQL 18 client;
+- create PostgreSQL 18-client custom-format dumps for `polytopia2`,
+  `polytopia_dev`, and `twospies`;
+- validate every custom-format dump with PostgreSQL 18 `pg_restore --list`;
+- keep a checksum manifest.
+
+Using the newer dump programs is consistent with PostgreSQL's recommendation
+for major-version dump/restore planning.
+
+## Phase PG5: maintenance-window cutover
+
+1. Confirm the bot is healthy and `polyapi.service` is inactive.
+2. Stop `polytopia.service`.
+3. Confirm no application sessions remain.
+4. Take and validate a final stopped-service cluster-wide logical backup.
+5. Stop PostgreSQL 12 and the empty PostgreSQL 18 destination.
+6. Run the rehearsed copy-mode cluster upgrade as `postgres`.
+7. Confirm the wrapper assigns PostgreSQL 18 the production port 5432 and
+   leaves PostgreSQL 12 stopped, independent, and in manual startup mode on a
+   nonproduction port.
+8. Compare the migrated PostgreSQL 18 configuration with the archived
+   PostgreSQL 12 configuration.
+9. Confirm localhost-only listening and all `pg_hba.conf` rules, especially
+   the `polybot_dev` rejection from `polytopia2`.
+10. Start PostgreSQL 18 and verify roles, owners, databases, extensions,
+    encodings, locales, sizes, and key row counts.
+11. Run any analyze/rebuild scripts produced by `pg_upgrade`.
+12. Run:
+
+    ```bash
+    sudo -u postgres /usr/lib/postgresql/18/bin/vacuumdb \
+      --all --analyze-in-stages --missing-stats-only
+    ```
+
+13. Start `polytopia.service` temporarily with `--skip_tasks`.
+14. Verify production bot identity, PostgreSQL 18 server version, database
+    access, guilds, Bullet loading, and read-only commands.
+15. Replace the canary command with the permanent systemd drop-in, restart the
+    bot with tasks enabled, and observe both services for at least ten minutes.
+
+## Rollback
+
+Copy mode leaves PostgreSQL 12 independent. During the task-disabled canary:
+
+1. Stop `polytopia.service`.
+2. Stop PostgreSQL 18.
+3. Restore the archived PostgreSQL 12 port/startup configuration.
+4. Start PostgreSQL 12 on port 5432.
+5. Confirm the expected server version, databases, roles, authentication, and
+   key row counts.
+6. Start the task-disabled bot and smoke-test it before enabling tasks.
+
+The exact port/configuration commands must come from the rehearsal because
+`pg_upgradecluster` adjusts the old cluster to an unused port and manual
+startup.
+
+Rollback becomes potentially lossy after PostgreSQL 18 accepts production
+writes: those writes are absent from the copied PostgreSQL 12 cluster. Keep
+the canary short and task-disabled. If writes must be preserved, stop both
+systems and perform a separately approved logical reconciliation rather than
+blindly starting PostgreSQL 12.
+
+A full logical restore is the last-resort recovery path. It is slower and
+would discard activity after the selected dump, so it requires separate
+approval.
+
+## Success criteria
+
+- PostgreSQL 18 is the only cluster listening on production port 5432.
+- The server reports the reviewed current PostgreSQL 18 minor release.
+- All expected databases, roles, ownership, encodings, and locales match.
+- `polytopia2`, `polytopia_dev`, and preserved `twospies` data compare.
+- Local-only networking and HBA isolation are unchanged.
+- The Python 3.12 bot connects without database or extension errors.
+- Read-only Discord smoke checks and background tasks pass.
+- PostgreSQL and bot processes remain stable for at least ten minutes.
+- Fresh PostgreSQL 18 backups pass validation.
+- PostgreSQL 12 remains stopped and independently recoverable.
+
+## Deferred cleanup
+
+After at least one to two weeks of stable PostgreSQL 18 operation and multiple
+validated backup cycles, request separate approval to:
+
+- remove the old PostgreSQL 12 cluster with `pg_dropcluster`;
+- remove unsupported PostgreSQL 12 packages;
+- remove PostgreSQL 14 packages if no longer needed;
+- delete disposable rehearsal artifacts;
+- decide whether to retain or delete the `twospies` database;
+- update monitoring and disk-audit expectations.
+
+Do not combine old-cluster removal with the cutover approval.

--- a/docs/POSTGRESQL_UPGRADE_PLAN.md
+++ b/docs/POSTGRESQL_UPGRADE_PLAN.md
@@ -1,8 +1,9 @@
 # PostgreSQL 12 to 18 upgrade plan
 
-This document plans a PostgreSQL server upgrade for `racknerd`. It does not
-authorize package installation, cluster creation/removal, a PostgreSQL
-restart, a database restore, or a production-bot restart.
+This document plans and records a PostgreSQL server upgrade for `racknerd`.
+Completing one phase does not authorize a later phase, cluster
+creation/removal, a PostgreSQL restart, a database restore, or a
+production-bot restart.
 
 ## Recommendation
 
@@ -34,6 +35,8 @@ Recorded on 2026-07-28:
 - PostgreSQL listens only on localhost
 - data checksums are disabled on the PostgreSQL 12 cluster
 - only the built-in `plpgsql` extension is installed in `polytopia2`
+- PostgreSQL 18.4 server and client packages are installed from PGDG, but no
+  PostgreSQL 18 data cluster exists yet
 
 Clusters:
 
@@ -131,7 +134,7 @@ sudo pg_dropcluster --stop 14 main
 The PostgreSQL 14 packages were intentionally retained. Package cleanup remains
 a distinct later action.
 
-## Phase PG2: install PostgreSQL 18 without cutting over
+## Phase PG2 completed: install PostgreSQL 18 without cutting over
 
 Ubuntu 22.04's distribution repository stops at PostgreSQL 14. Use the official
 PostgreSQL Apt repository, which supports `jammy` and publishes PostgreSQL 18.
@@ -161,8 +164,26 @@ sudo pg_ctlcluster 18 main stop
 pg_lsclusters
 ```
 
-Package installation is a separately approved system change. It is not
-approval to upgrade the data cluster.
+Nelluk separately approved PG2. The Apt simulation showed three upgrades,
+four new packages, no removals, and no PostgreSQL 12 package change. On
+2026-07-28 the following PGDG packages were installed:
+
+- `postgresql-18`, `postgresql-client-18`, and `postgresql-18-jit` 18.4
+- `postgresql-common` and `postgresql-client-common` 293
+- `libpq5` 18.4
+
+Installation did not create an `18/main` cluster. Post-install verification
+confirmed:
+
+- `12/main` remained online on port 5432 and was the only registered cluster;
+- PostgreSQL continued listening only on `127.0.0.1` and `::1`;
+- the production server reported version 12.20 and database `polytopia2`;
+- the default `psql` client reported version 18.4;
+- `polytopia.service` retained PID 1480385 with zero restarts;
+- approximately 4.2 GiB remained free on `/`.
+
+No cluster was created, stopped, restarted, upgraded, or restored during PG2.
+Completion of PG2 is not approval to begin the disposable PG3 rehearsal.
 
 ## Phase PG3: rehearsal and compatibility proof
 

--- a/docs/POSTGRESQL_UPGRADE_PLAN.md
+++ b/docs/POSTGRESQL_UPGRADE_PLAN.md
@@ -40,13 +40,16 @@ Clusters:
 | Version | Port | State | Purpose |
 | --- | ---: | --- | --- |
 | 12.20 | 5432 | online | active production and development data |
-| 14.23 | 5433 | online | verified unused default Ubuntu cluster |
+| 14.23 | 5433 | removed | verified unused default Ubuntu cluster |
 
 The PostgreSQL 14 cluster was inspected as `postgres` on 2026-07-28. It
 contains only the connectable `postgres` and `template1` databases at about
 8.6 MB each, only built-in roles plus `postgres`, and no client session other
 than the inspection query. It also rejects local login as `nelluk` because
-that role does not exist. This confirms it is an unused default cluster.
+that role does not exist. This confirmed it was an unused default cluster.
+After explicit approval, `14/main` was removed. Its data and configuration
+directories and port-5433 listener are absent; PostgreSQL 14 packages remain
+installed.
 
 Databases in the PostgreSQL 12 cluster:
 
@@ -119,14 +122,14 @@ sudo -u postgres psql -X -P pager=off -p 5433 -d postgres \
 ```
 
 The output confirmed only default databases/roles and no client. Its removal
-is still a separate destructive approval:
+was separately approved and completed with:
 
 ```bash
 sudo pg_dropcluster --stop 14 main
 ```
 
-Do not remove the PostgreSQL 14 packages yet. The cluster removal and package
-cleanup are distinct actions.
+The PostgreSQL 14 packages were intentionally retained. Package cleanup remains
+a distinct later action.
 
 ## Phase PG2: install PostgreSQL 18 without cutting over
 

--- a/docs/POSTGRESQL_UPGRADE_PLAN.md
+++ b/docs/POSTGRESQL_UPGRADE_PLAN.md
@@ -185,37 +185,104 @@ confirmed:
 No cluster was created, stopped, restarted, upgraded, or restored during PG2.
 Completion of PG2 is not approval to begin the disposable PG3 rehearsal.
 
-## Phase PG3: rehearsal and compatibility proof
+## Phase PG3 completed: rehearsal and compatibility proof
 
-Use a disposable PostgreSQL 18 cluster on a nonproduction port. Restore a
-logical production dump and test without Discord:
+The rehearsal used this production-isolated sequence:
 
-1. Create a fresh PostgreSQL 18 test cluster on an unused port.
-2. Use PostgreSQL 18 client tools to dump from PostgreSQL 12.
-3. Restore `polytopia2` into the test cluster.
+1. Create a fresh PostgreSQL 12 source cluster on an unused port.
+2. Create and validate PostgreSQL 12 and PostgreSQL 18 client dumps from the
+   live PostgreSQL 12 server.
+3. Restore every application database and the required roles into the
+   disposable PostgreSQL 12 source.
 4. Compare database ownership, encoding, locale, schema, table counts, and
    representative row counts.
-5. Compare the largest/high-value tables:
-   `gamelog`, `lineup`, `gameside`, `game`, `player`, and `discordmember`.
-6. Run representative Peewee reads, writes inside rolled-back transactions,
-   graph rendering, and API route tests against PostgreSQL 18.
-7. Run the Python 3.12 application test suite.
-8. Run the exact `pg_upgrade --check`/`pg_upgradecluster` preflight intended for
-   production and preserve its output.
-9. Measure restore and upgrade duration to size the maintenance window.
-10. Remove only the disposable rehearsal cluster after its results are
-    reviewed and separately approved.
+5. Run representative Peewee reads, writes inside rolled-back transactions,
+   graph rendering, API route tests, and the complete Python 3.12 suite.
+6. Copy the production HBA policy into the disposable source.
+7. Run the complete production-shaped `pg_upgradecluster` copy-mode command
+   against only the disposable source.
+8. Repeat the structural, row-count, HBA, access-policy, and application tests
+   against PostgreSQL 18.
+9. Restore PostgreSQL 18-generated archives into derived probe databases.
+10. Retain the two rehearsal clusters until their results and cleanup receive
+    separate approval.
 
-The rehearsal will establish the exact `pg_upgradecluster` syntax delivered by
-the installed `postgresql-common` version. The anticipated production command
-is equivalent to:
+The installed `pg_upgradecluster --check` option checks required packages; it
+does not run PostgreSQL's binary compatibility checks. A meaningful rehearsal
+therefore used a disposable PostgreSQL 12 source cluster and performed the
+complete copy-mode upgrade. This exercised the real `pg_upgrade` consistency
+checks without stopping production.
+
+On 2026-07-28:
+
+- `12/rehearsal` was created on port 5434 with UTF8 encoding,
+  `en_US.UTF-8` locale, and data checksums disabled, matching production.
+- Private PostgreSQL 12 and PostgreSQL 18 logical archives were created for
+  `polytopia2`, `polytopia_dev`, and `twospies`, plus globals. The directory
+  is mode 0700 and the archive files are mode 0600.
+- Both client generations dumped `polytopia2` in approximately 23 seconds.
+  All six custom archives passed their matching `pg_restore --list`.
+- The PostgreSQL 12 archives restored into `12/rehearsal` without error.
+  Restoring `polytopia2` took approximately 25 seconds.
+- Snapshot row-count differences from live production were limited to one
+  `discordmember`, one `player`, and two `gamelog` rows added after the dump
+  began. Relationship-table counts matched exactly.
+- All 54 Python 3.12 tests passed against the restored PostgreSQL 12
+  `polytopia_dev`, including five database integration tests.
+- The production HBA file was copied to the disposable source so the rehearsal
+  also tested preservation of the isolated-development-role rejection rules.
+- The package preflight passed, after which this exact command upgraded only
+  the disposable cluster:
+
+```bash
+sudo pg_upgradecluster \
+  --method=upgrade \
+  --jobs=2 \
+  --rename=rehearsal18 \
+  -v 18 \
+  12 rehearsal
+```
+
+The copy-mode upgrade completed in approximately 22 seconds. The wrapper ran
+the full PostgreSQL compatibility checks and staged optimizer statistics. It
+left `12/rehearsal` stopped in manual mode on port 5433 and started
+`18/rehearsal18` on port 5434.
+
+Post-upgrade verification confirmed:
+
+- PostgreSQL 18.4 reported the expected owners, UTF8 encoding,
+  `en_US.UTF-8` locale, and disabled data checksums for all databases.
+- The six high-value table row counts exactly matched the restored snapshot.
+- `polytopia2` retained 17 tables, 55 indexes, 17 sequences, 148 columns,
+  23 foreign keys, and 17 primary keys, with no invalid index.
+- PostgreSQL 18 additionally represents 101 existing `NOT NULL` attributes as
+  catalog constraint type `n`; this explains its larger raw constraint count.
+- Every database's recorded and actual collation version matched at 2.35.
+- The migrated PostgreSQL 18 HBA file was byte-equivalent to production.
+- `polybot_dev` could connect to `polytopia_dev` but was rejected from
+  `polytopia2`.
+- All 54 Python 3.12 tests passed again against PostgreSQL 18.
+- A schema-only restore of the PostgreSQL 18 `polytopia2` archive reproduced
+  the exact schema object counts, and a full restore of the PostgreSQL 18
+  `polytopia_dev` archive reproduced all representative row counts.
+- The two derived restore-probe databases were removed after validation.
+- Production `12/main` stayed online on port 5432, and
+  `polytopia.service` retained PID 1480385 with zero restarts.
+
+The rehearsal temporarily raised root-filesystem use to 91%, with
+approximately 2.0 GiB free. The stopped PostgreSQL 12 rehearsal cluster,
+online PostgreSQL 18 rehearsal cluster, and private rehearsal archives remain
+pending separately approved cleanup.
+
+The rehearsed production command is equivalent to:
 
 ```text
 pg_upgradecluster --method=upgrade --jobs=2 -v 18 12 main
 ```
 
-Do not execute that command against production until the rehearsal proves its
-port, configuration-copy, old-cluster retention, and rollback behavior.
+The rehearsal proved its port, configuration-copy, old-cluster retention, and
+rollback behavior. Executing it against production still requires completion
+of PG4 and separate maintenance-window approval for PG5.
 
 ## Phase PG4: pre-cutover backup set
 

--- a/docs/PRODUCTION_CUTOVER.md
+++ b/docs/PRODUCTION_CUTOVER.md
@@ -1,13 +1,32 @@
 # Python 3.12 production cutover and rollback
 
-This is the reviewed runbook for moving the production PolyELO bot from its
-legacy Python 3.9 virtual environment to the uv-managed Python 3.12
-environment. It is documentation, not authorization to deploy.
+This runbook records the reviewed and completed move of the production PolyELO
+bot from its legacy Python 3.9 virtual environment to the uv-managed Python
+3.12 environment. It also remains the recovery reference for this deployment;
+it is not standing authorization for a future deployment or rollback.
+
+## Completion record
+
+- Pull request 136 was merged as
+  `75b24b5e79e997477014aa979d87dc5f6d162bc5`.
+- The production cutover completed successfully on 2026-07-28.
+- A task-disabled Python 3.12 canary passed startup and command smoke checks
+  before background tasks were enabled.
+- The final process passed a five-minute stability window with no restart,
+  traceback, unauthorized guild, database error, or extension failure.
+- The permanent systemd drop-in matched the reviewed tracked file exactly.
+- `polyapi.service` remained disabled and inactive.
+- PostgreSQL was not upgraded, restored, or reconfigured.
+- The pre-cutover and stopped-service recovery artifacts are stored in the
+  private directory
+  `/home/nelluk/backups/polybot-cutover-20260728T173159-0400`.
 
 ## Scope and fixed boundaries
 
 - Production checkout: `/home/nelluk/PolyBot39`
 - Reviewed pre-upgrade commit: `43b3425`
+- Reviewed merge commit:
+  `75b24b5e79e997477014aa979d87dc5f6d162bc5`
 - Upgrade branch: `dev-dependency-upgrade`
 - Production service: `polytopia.service`
 - Production database: `polytopia2`
@@ -30,10 +49,8 @@ service update.
 
 ## Reviewed state
 
-- `origin/master` at the review baseline is an ancestor of all seven focused
-  upgrade commits.
-- The full upgrade changes 29 files with 3,881 insertions and 113 deletions
-  before this Phase 8 documentation commit.
+- The merged upgrade contains eight focused commits after `43b3425`.
+- The merged upgrade changes 35 files with 4,337 insertions and 185 deletions.
 - The production checkout is clean at `43b3425`.
 - `polytopia.service` is active and runs:
 
@@ -112,9 +129,10 @@ profile and changes only the interpreter used by `polytopia.service`.
 
 ## Approval gate
 
-Everything below changes or exercises production. Do not run it until Nelluk
-has explicitly approved the production cutover and an acceptable maintenance
-window.
+The commands below are the completed procedure and a future recovery
+reference. Everything below changes or exercises production. Do not repeat any
+part of it until Nelluk has explicitly approved the exact production action
+and an acceptable maintenance window.
 
 ## Cutover commands
 
@@ -123,6 +141,7 @@ window.
 ```bash
 export POLYBOT_ROOT=/home/nelluk/PolyBot39
 export POLYBOT_ROLLBACK_COMMIT=43b3425
+export POLYBOT_UPGRADE_COMMIT=75b24b5e79e997477014aa979d87dc5f6d162bc5
 cd "$POLYBOT_ROOT"
 git status --short --branch
 git rev-parse HEAD
@@ -136,11 +155,22 @@ Stop if the production checkout is dirty, the bot is not active, the API is
 active, the current commit is unexpected, or disk space is materially below
 the reviewed value.
 
-### 2. Create and validate fresh backups
+### 2. Preserve ignored state and create fresh backups
 
-This step connects to the production database and writes backup files:
+This step connects to the production database and writes backup files. The
+deployed `/home/nelluk/backup_db.sh` must match the reviewed source at
+`scripts/backup_db.sh`:
 
 ```bash
+export POLYBOT_CUTOVER_ARCHIVE=/home/nelluk/backups/polybot-cutover-$(date +%Y%m%dT%H%M%S%z)
+install -d -m 0700 "$POLYBOT_CUTOVER_ARCHIVE"
+install -m 0600 /home/nelluk/PolyBot39/config.ini \
+  "$POLYBOT_CUTOVER_ARCHIVE/config.ini"
+install -m 0600 /home/nelluk/PolyBot39/server_settings.py \
+  "$POLYBOT_CUTOVER_ARCHIVE/server_settings.py"
+install -m 0600 /home/nelluk/PolyBot39/spreadsheet_creds.json \
+  "$POLYBOT_CUTOVER_ARCHIVE/spreadsheet_creds.json"
+
 /home/nelluk/backup_db.sh
 stat /home/nelluk/polytopia_full_backup.sqlc
 ls -lh /home/nelluk/backups/polytopia_bak-*.sqlc
@@ -150,7 +180,8 @@ ls -lh /home/nelluk/backups/polytopia_images-*.tar.gz
 
 Confirm that the full dump and current weekday image archive have fresh
 timestamps and nonzero sizes. Do not continue after any backup or validation
-error.
+error. The hardened backup script writes and validates temporary files before
+atomically replacing the published backup paths, and refuses overlapping runs.
 
 ### 3. Fast-forward to the reviewed merge
 
@@ -161,6 +192,7 @@ The upgrade branch must already be reviewed, pushed, and merged into
 cd "$POLYBOT_ROOT"
 git fetch origin
 git merge-base --is-ancestor "$POLYBOT_ROLLBACK_COMMIT" origin/master
+test "$(git rev-parse origin/master)" = "$POLYBOT_UPGRADE_COMMIT"
 git pull --ff-only origin master
 git log --oneline "$POLYBOT_ROLLBACK_COMMIT"..HEAD
 git status --short --branch
@@ -173,6 +205,9 @@ reviewed upgrade, or leaves a dirty worktree.
 
 ```bash
 nano /home/nelluk/PolyBot39/config.ini
+chmod 600 \
+  /home/nelluk/PolyBot39/config.ini \
+  /home/nelluk/PolyBot39/spreadsheet_creds.json
 ```
 
 Do not start or import the bot yet. The redacted configuration check runs with
@@ -207,50 +242,108 @@ disabled HTTP API, enabled Bullet integration, and the production image/log
 roots. The inspection command does not import models or connect to external
 systems.
 
-### 6. Install and inspect the systemd drop-in
+### 6. Stop the legacy bot and create the final recovery point
 
-These are the sudo commands Nelluk must run:
+This is the beginning of downtime. The earlier backup protects preparation;
+this second backup captures a recovery point after the only application that
+writes the database has stopped.
+
+```bash
+sudo systemctl stop polytopia.service
+systemctl show polytopia.service \
+  -p ActiveState -p SubState -p MainPID --no-pager
+
+/home/nelluk/backup_db.sh
+/usr/bin/pg_restore --list /home/nelluk/polytopia_full_backup.sqlc >/dev/null
+tar -tzf "/home/nelluk/backups/polytopia_images-$(date +%A).tar.gz" >/dev/null
+
+export POLYBOT_STOPPED_STAMP=$(date +%Y%m%dT%H%M%S%z)
+install -m 0600 /home/nelluk/polytopia_full_backup.sqlc \
+  "$POLYBOT_CUTOVER_ARCHIVE/final-stopped-polytopia-full-${POLYBOT_STOPPED_STAMP}.sqlc"
+install -m 0600 "/home/nelluk/backups/polytopia_bak-$(date +%A).sqlc" \
+  "$POLYBOT_CUTOVER_ARCHIVE/final-stopped-polytopia-partial-${POLYBOT_STOPPED_STAMP}.sqlc"
+install -m 0600 "/home/nelluk/backups/polytopia_images-$(date +%A).tar.gz" \
+  "$POLYBOT_CUTOVER_ARCHIVE/final-stopped-images-${POLYBOT_STOPPED_STAMP}.tar.gz"
+```
+
+Validate both custom-format dumps and the copied image archive. Do not start a
+new bot process after any backup or validation failure.
+
+### 7. Start a task-disabled Python 3.12 canary
+
+Create `/tmp/polybot39-canary-upgrade.conf` with:
+
+```ini
+[Service]
+Environment=POLYBOT_ENV=production
+ExecStart=
+ExecStart=/home/nelluk/PolyBot39/.venv/bin/python /home/nelluk/PolyBot39/bot.py --skip_tasks
+```
+
+Install and inspect it:
 
 ```bash
 sudo install -d -m 0755 /etc/systemd/system/polytopia.service.d
+sudo install -m 0644 \
+  /tmp/polybot39-canary-upgrade.conf \
+  /etc/systemd/system/polytopia.service.d/upgrade.conf
+sudo systemctl daemon-reload
+systemctl cat polytopia.service --no-pager
+sudo systemctl start polytopia.service
+```
+
+The canary deliberately retains the base unit's existing restart policy; the
+completed cutover did not add a restart-policy override. Confirm that the
+effective `ExecStart` uses `.venv/bin/python`, selects the production profile,
+and ends with `--skip_tasks`.
+
+### 8. Canary smoke checklist
+
+- The service stays active with a stable, new PID and zero restarts.
+- The database opens and the Discord gateway connects.
+- Runtime bot-ID validation accepts production bot `484067640302764042`.
+- Expected production guilds load and no unauthorized guild is retained.
+- The Bullet extension loads without error.
+- No background task loop starts.
+- The normal production prefix responds to `guide`.
+- A read-only player lookup and team lookup render.
+- One existing local-image team card renders.
+- No development path, database, bot ID, or `!` prefix appears.
+- `polyapi.service` remains inactive.
+
+Do not create or correct a production game merely for smoke testing. Use the
+immediate rollback if identity, guild, database, or extension checks fail.
+
+### 9. Activate background tasks and observe
+
+Replace the temporary canary drop-in with the reviewed permanent file:
+
+```bash
 sudo install -m 0644 \
   /home/nelluk/PolyBot39/deploy/systemd/polytopia.service.d/upgrade.conf \
   /etc/systemd/system/polytopia.service.d/upgrade.conf
 sudo systemctl daemon-reload
 systemctl cat polytopia.service --no-pager
+sudo systemctl restart polytopia.service
 ```
 
-Confirm that the effective unit has `POLYBOT_ENV=production` and the new
-`.venv/bin/python` `ExecStart`. Installing the drop-in and reloading systemd
-does not restart the currently running bot.
-
-### 7. Perform the one approved restart
+Confirm that `--skip_tasks` is absent and that the installed file checksum
+matches the tracked file. Observe the service for at least five minutes:
 
 ```bash
-sudo systemctl restart polytopia.service
 systemctl show polytopia.service \
-  -p ActiveState -p SubState -p MainPID -p ExecStart --no-pager
-journalctl -u polytopia.service --since "5 minutes ago" --no-pager
+  -p ActiveState -p SubState -p MainPID -p ExecStart \
+  -p NRestarts -p Result --no-pager
+journalctl -u polytopia.service --since "10 minutes ago" --no-pager
+systemctl show polyapi.service -p ActiveState -p SubState --no-pager
+git status --short --branch
 ```
 
-Stop and use the rollback below if the service is not active, repeatedly
-restarts, authenticates as the wrong bot, loads an unauthorized guild, reports
-database errors, or cannot load the Bullet extension.
-
-### 8. Production smoke checklist
-
-- The log reports Python/discord.py startup and bot ID `484067640302764042`.
-- Expected production guilds load; no guild is unexpectedly left.
-- Gateway heartbeats remain healthy for at least five minutes.
-- The normal production prefix responds to `guide`.
-- A read-only player lookup and team lookup render.
-- One existing local-image team card renders.
-- No development path, database, bot ID, or `!` prefix appears.
-- Background tasks run without a new exception.
-- `polyapi.service` remains inactive.
-- The service PID differs from the pre-cutover PID and remains stable.
-
-Do not create or correct a production game merely for smoke testing.
+Background matchmaking, reminder, match-list, and confirmation tasks must run
+without a new exception. Stop and use the rollback below if the service is not
+active, repeatedly restarts, authenticates as the wrong bot, loads an
+unauthorized guild, reports database errors, or cannot load the Bullet
+extension.
 
 ## Immediate rollback
 
@@ -271,19 +364,24 @@ journalctl -u polytopia.service --since "5 minutes ago" --no-pager
 The unchanged base unit then uses
 `/home/nelluk/PolyBot39/bin/python3 /home/nelluk/PolyBot39/bot.py`. The ignored
 production configuration, server settings, spreadsheet credentials, images,
-logs, legacy environment, and new `.venv` remain in place.
+logs, legacy environment, and new `.venv` remain in place. Timestamped copies
+of the ignored configuration and both pre-cutover and stopped-service recovery
+points remain in the private cutover archive.
 
-After the incident is understood, return the checkout to the branch without
-discarding anything:
-
-```bash
-cd /home/nelluk/PolyBot39
-git switch master
-```
+Leave the checkout detached at `43b3425` while the legacy systemd command is
+active. Do **not** switch back to upgraded `master` while the drop-in is
+removed: a later restart would then run upgraded source under the legacy
+Python 3.9 interpreter. Return to `master` only as part of a reviewed recovery
+that also restores the Python 3.12 drop-in, or deploy a separately reviewed
+legacy-compatible recovery branch.
 
 A database restore is an exceptional data-recovery action, not a dependency
 rollback step. It would discard legitimate activity after the dump and
 requires its own explicit approval.
+
+Retain the legacy Python 3.9 environment and private cutover archive through a
+settling period. Their later removal is a separately approved cleanup action,
+not part of the cutover.
 
 ## Separately gated API work
 

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,42 +1,144 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# A simple script to perform postgres db backup.
+# Back up the production PolyBot PostgreSQL database and local team images.
+# Generate and validate private temporary files before atomically publishing
+# them, so a failed run cannot truncate the last known-good backup.
 
 set -o pipefail
+umask 077
 
-DAY=$(date +%A)
+DAY=$(/usr/bin/date +%A)
 TARGET=/home/nelluk/backups/polytopia_bak-${DAY}.sqlc
 LOGTARGET=/home/nelluk/backups/polytopia_gamelogs.csv.gz
 FULLTARGET=/home/nelluk/polytopia_full_backup.sqlc
 IMAGEDIR=/home/nelluk/PolyBot39/data/images
 IMAGETARGET=/home/nelluk/backups/polytopia_images-${DAY}.tar.gz
+LOCKFILE=/home/nelluk/.backup_db.lock
 
-backup_failed=0
+TARGET_TMP=
+LOGTARGET_TMP=
+FULLTARGET_TMP=
+IMAGETARGET_TMP=
 
-# backup db minus log table, and log table minus protected logs, to ~/backups which multiple people have link to
-/usr/bin/pg_dump -U nelluk -Fc --exclude-table=gamelog polytopia2 > "$TARGET" || backup_failed=1
-/usr/bin/psql -c "COPY (SELECT id, message_ts, guild_id, message FROM gamelog WHERE gamelog.is_protected = FALSE ORDER BY id ASC) TO stdout DELIMITER ',' CSV HEADER" --dbname=polytopia2 | gzip > "$LOGTARGET" || backup_failed=1
+cleanup() {
+  for temporary_file in \
+    "$TARGET_TMP" \
+    "$LOGTARGET_TMP" \
+    "$FULLTARGET_TMP" \
+    "$IMAGETARGET_TMP"
+  do
+    if [ -n "$temporary_file" ]
+    then
+      /usr/bin/rm -f -- "$temporary_file"
+    fi
+  done
+}
 
-# backup full db to one non-rolling location
-/usr/bin/pg_dump -U nelluk -Fc polytopia2 > "$FULLTARGET" || backup_failed=1
-
-# backup local images to a weekday-rotated archive
-if [ -d "$IMAGEDIR" ]
-then
-  tar -czf "$IMAGETARGET" -C "$IMAGEDIR" . || backup_failed=1
-else
-  echo "Image directory $IMAGEDIR does not exist; skipping image backup" >&2
-fi
-
-if [ "$backup_failed" -eq 0 ]
-then
-  echo "Backup successful to file $TARGET"
-  exit 0
-else
-  echo "Error during database or image backup" >&2
+fail() {
+  echo "Backup failed: $1" >&2
   exit 1
+}
+
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+exec 9>"$LOCKFILE" || fail "cannot open lock file $LOCKFILE"
+if ! /usr/bin/flock -n 9
+then
+  fail "another backup run already holds $LOCKFILE"
 fi
 
-# to restore backup:
-# drop database dbname;
-# pg_restore -C -d postgres backup_file.sqlc -O   (use a built in db name like postgres or nelluk as a place from which to issue the commands)
+if [ ! -d /home/nelluk/backups ]
+then
+  fail "backup directory /home/nelluk/backups does not exist"
+fi
+
+if [ ! -d "$IMAGEDIR" ]
+then
+  fail "image directory $IMAGEDIR does not exist"
+fi
+
+TARGET_TMP=$(/usr/bin/mktemp "${TARGET}.tmp.XXXXXX") \
+  || fail "cannot create temporary partial dump"
+LOGTARGET_TMP=$(/usr/bin/mktemp "${LOGTARGET}.tmp.XXXXXX") \
+  || fail "cannot create temporary gamelog export"
+FULLTARGET_TMP=$(/usr/bin/mktemp "${FULLTARGET}.tmp.XXXXXX") \
+  || fail "cannot create temporary full dump"
+IMAGETARGET_TMP=$(/usr/bin/mktemp "${IMAGETARGET}.tmp.XXXXXX") \
+  || fail "cannot create temporary image archive"
+
+if ! /usr/bin/pg_dump \
+  -U nelluk \
+  -Fc \
+  --exclude-table=gamelog \
+  --file="$TARGET_TMP" \
+  polytopia2
+then
+  fail "partial PostgreSQL dump command failed"
+fi
+
+if ! /usr/bin/pg_restore --list "$TARGET_TMP" >/dev/null
+then
+  fail "partial PostgreSQL dump validation failed"
+fi
+
+if ! /usr/bin/psql \
+  --dbname=polytopia2 \
+  --command="COPY (SELECT id, message_ts, guild_id, message FROM gamelog WHERE gamelog.is_protected = FALSE ORDER BY id ASC) TO stdout DELIMITER ',' CSV HEADER" \
+  | /usr/bin/gzip >"$LOGTARGET_TMP"
+then
+  fail "gamelog export command failed"
+fi
+
+if ! /usr/bin/gzip -t "$LOGTARGET_TMP"
+then
+  fail "gamelog gzip validation failed"
+fi
+
+if ! /usr/bin/pg_dump \
+  -U nelluk \
+  -Fc \
+  --file="$FULLTARGET_TMP" \
+  polytopia2
+then
+  fail "full PostgreSQL dump command failed"
+fi
+
+if ! /usr/bin/pg_restore --list "$FULLTARGET_TMP" >/dev/null
+then
+  fail "full PostgreSQL dump validation failed"
+fi
+
+if ! /usr/bin/tar -czf "$IMAGETARGET_TMP" -C "$IMAGEDIR" .
+then
+  fail "image archive command failed"
+fi
+
+if ! /usr/bin/tar -tzf "$IMAGETARGET_TMP" >/dev/null
+then
+  fail "image archive validation failed"
+fi
+
+/usr/bin/mv -f -- "$TARGET_TMP" "$TARGET" \
+  || fail "cannot publish partial PostgreSQL dump"
+TARGET_TMP=
+
+/usr/bin/mv -f -- "$LOGTARGET_TMP" "$LOGTARGET" \
+  || fail "cannot publish gamelog export"
+LOGTARGET_TMP=
+
+/usr/bin/mv -f -- "$FULLTARGET_TMP" "$FULLTARGET" \
+  || fail "cannot publish full PostgreSQL dump"
+FULLTARGET_TMP=
+
+/usr/bin/mv -f -- "$IMAGETARGET_TMP" "$IMAGETARGET" \
+  || fail "cannot publish image archive"
+IMAGETARGET_TMP=
+
+echo "Backup successful:"
+echo "  partial database: $TARGET"
+echo "  public gamelog:   $LOGTARGET"
+echo "  full database:    $FULLTARGET"
+echo "  local images:     $IMAGETARGET"

--- a/tests/test_deployment_assets.py
+++ b/tests/test_deployment_assets.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import subprocess
 import unittest
 
 
@@ -32,11 +33,37 @@ class ProductionDeploymentAssetTests(unittest.TestCase):
         self.assertIn('uv sync --locked --no-dev --python 3.12.13', runbook)
         self.assertIn('POLYBOT_ROLLBACK_COMMIT=43b3425', runbook)
         self.assertIn(
+            '75b24b5e79e997477014aa979d87dc5f6d162bc5',
+            runbook,
+        )
+        self.assertIn('final-stopped-polytopia-full-', runbook)
+        self.assertIn('/home/nelluk/PolyBot39/bot.py --skip_tasks', runbook)
+        self.assertIn(
             '/home/nelluk/PolyBot39/bin/python3 '
             '/home/nelluk/PolyBot39/bot.py',
             runbook,
         )
         self.assertIn('polyapi.service` remains inactive', runbook)
+        self.assertNotIn('git switch master', runbook)
+
+    def test_backup_script_is_syntactically_valid_and_atomic(self):
+        script = self.root / 'scripts/backup_db.sh'
+        result = subprocess.run(
+            ['/usr/bin/bash', '-n', script],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        source = script.read_text(encoding='utf-8')
+        self.assertIn('/usr/bin/flock -n 9', source)
+        self.assertIn('/usr/bin/mktemp', source)
+        self.assertIn('/usr/bin/pg_restore --list', source)
+        self.assertIn('/usr/bin/gzip -t', source)
+        self.assertIn('/usr/bin/tar -tzf', source)
+        self.assertIn('/usr/bin/mv -f --', source)
+        self.assertNotIn('> "$TARGET"', source)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- harden `backup_db.sh` with overlap protection, private permissions, validation, and atomic publication
- add deployment tests for the backup workflow and completed canary/recovery procedure
- record the successful Python 3.12 production cutover
- document and record the successfully rehearsed and completed PostgreSQL 12-to-18 production upgrade

## Operational outcome

Production now runs the bot under the uv-managed CPython 3.12 environment and PostgreSQL 18.4. The PostgreSQL cutover preserved roles, owners, databases, HBA isolation, schema, representative row counts, and localhost-only access. A task-disabled canary and the final task-enabled service both passed live command and stability checks.

The deployed `/home/nelluk/backup_db.sh` exactly matches the tracked script in this branch. It now refuses overlapping runs, writes private same-filesystem temporary artifacts, validates database/image archives, and atomically replaces published backups only after success.

The old PostgreSQL 12 cluster and legacy Python 3.9 environment remain retained for the documented settling period. Their later removal is separately gated cleanup. `twospies` remains preserved. `polyapi.service` remains disabled and inactive.

## Validation

- 54/54 Python 3.12 tests passed against PostgreSQL 18, including all five development-database integration tests
- offline suite: 49 passed, 5 expected database skips
- `uv lock --check` passed with 80 packages
- `bash -n scripts/backup_db.sh`
- `git diff --check`
- live production backup and stopped-service recovery archives validated during cutover
- deployed and tracked hardened backup-script SHA-256 checksums match
- production bot and PostgreSQL 18 completed the recorded stability window with stable PIDs and zero restarts

## Scope

This PR records already completed operational work and brings the tracked backup source in line with the deployed script. Merging it does not itself install packages, create or remove clusters, restore databases, restart PostgreSQL, restart the bot, or enable the API service.