### PR TITLE
Prepare post-upgrade cleanup

### DIFF
--- a/deploy/systemd/polytopia.service
+++ b/deploy/systemd/polytopia.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Polytopia Discord Bot
+After=multi-user.target
+
+[Service]
+User=nelluk
+Group=nelluk
+Type=idle
+Environment=POLYBOT_ENV=production
+ExecStart=/home/nelluk/PolyBot39/.venv/bin/python /home/nelluk/PolyBot39/bot.py
+WorkingDirectory=/home/nelluk/PolyBot39
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/polytopia.service.d/upgrade.conf
+++ b/deploy/systemd/polytopia.service.d/upgrade.conf
@@ -1,4 +1,0 @@
-[Service]
-Environment=POLYBOT_ENV=production
-ExecStart=
-ExecStart=/home/nelluk/PolyBot39/.venv/bin/python /home/nelluk/PolyBot39/bot.py

--- a/docs/POSTGRESQL_UPGRADE_PLAN.md
+++ b/docs/POSTGRESQL_UPGRADE_PLAN.md
@@ -475,3 +475,15 @@ validated backup cycles, request separate approval to:
 - update monitoring and disk-audit expectations.
 
 Do not combine old-cluster removal with the cutover approval.
+
+The repository-backed cleanup procedure is prepared in
+`docs/POST_UPGRADE_CLEANUP.md`. Its current status is **prepared, not
+executed**. It adds a canonical tracked systemd unit before either rollback
+environment is removed, preserves `twospies` and all current recovery
+archives, and requires a fresh backup plus service/database identity checks
+before the separately approved destructive phases.
+
+When cleanup completes, update this section with the actual evidence and mark
+the PostgreSQL 12 rollback section above as historical. Until then, the old
+cluster remains the stopped physical rollback copy described by the cutover
+record.

--- a/docs/POST_UPGRADE_CLEANUP.md
+++ b/docs/POST_UPGRADE_CLEANUP.md
@@ -1,0 +1,196 @@
+# PostgreSQL 18 and Python 3.12 post-upgrade cleanup
+
+Status: **Prepared; no production cleanup executed by this runbook yet**
+
+This runbook retires the rollback-only PostgreSQL 12 cluster and Python 3.9
+environment after the successful PostgreSQL 18 and Python 3.12 cutovers. Each
+host-changing phase requires Nelluk's explicit approval. Completing one phase
+does not authorize the next phase.
+
+## Fixed scope
+
+- Production checkout: `/home/nelluk/PolyBot39`
+- Production service: `polytopia.service`
+- Active Python environment: `/home/nelluk/PolyBot39/.venv`
+- Obsolete Python environment components:
+  `/home/nelluk/PolyBot39/bin`, `include`, `lib`, `lib64`, and `pyvenv.cfg`
+- Active database cluster: PostgreSQL `18/main` on port 5432
+- Obsolete stopped cluster: PostgreSQL `12/main` on port 5433
+- Retained databases: `polytopia2`, `polytopia_dev`, and `twospies`
+- Retained recovery material: current rotating PostgreSQL 18 backups, the PG4
+  archive, the final stopped-service archive, and the Python cutover archive
+
+Do not remove `.venv`, production configuration, credentials, images, logs,
+current backups, `twospies`, PostgreSQL 18, or shared PostgreSQL packages.
+Do not run `apt autoremove` as part of this cleanup.
+
+## C0 — Repository and systemd preparation
+
+The complete reviewed service is tracked at
+`deploy/systemd/polytopia.service`. It replaces the cutover-only tracked
+drop-in. Before host cleanup, verify it and record the live service state:
+
+```bash
+systemd-analyze verify deploy/systemd/polytopia.service
+systemctl cat polytopia.service --no-pager
+systemctl show polytopia.service \
+  -p MainPID -p NRestarts -p FragmentPath -p DropInPaths -p ExecStart \
+  --no-pager
+```
+
+Install the complete unit without restarting the running bot:
+
+```bash
+sudo install -m 0644 \
+  /home/nelluk/PolyBot39/deploy/systemd/polytopia.service \
+  /etc/systemd/system/polytopia.service
+sudo rm -f /etc/systemd/system/polytopia.service.d/upgrade.conf
+sudo rmdir --ignore-fail-on-non-empty \
+  /etc/systemd/system/polytopia.service.d
+sudo systemctl reenable polytopia.service
+sudo systemctl daemon-reload
+```
+
+Stop unless all of these are true:
+
+- `FragmentPath` is `/etc/systemd/system/polytopia.service`;
+- `DropInPaths` is empty;
+- `ExecStart` uses `/home/nelluk/PolyBot39/.venv/bin/python`;
+- the enablement link points to the `/etc` unit;
+- `MainPID` and `NRestarts` did not change.
+
+```bash
+systemctl cat polytopia.service --no-pager
+systemctl show polytopia.service \
+  -p MainPID -p NRestarts -p FragmentPath -p DropInPaths -p ExecStart \
+  --no-pager
+ls -l /etc/systemd/system/multi-user.target.wants/polytopia.service
+```
+
+Only after those checks pass, remove the obsolete non-package-owned base unit
+and verify enablement again:
+
+```bash
+sudo rm /lib/systemd/system/polytopia.service
+sudo systemctl daemon-reload
+systemctl is-enabled polytopia.service
+systemctl is-active polytopia.service
+systemctl cat polytopia.service --no-pager
+```
+
+This phase changes future service starts but does not restart the live bot.
+
+## C1 — Final backup and identity gate
+
+Refresh the observational disk audit, run the established production backup,
+and validate the resulting custom archive:
+
+```bash
+sudo systemctl start racknerd-disk-audit.service
+cat /home/nelluk/disk-audit-latest.txt
+df -h /
+/home/nelluk/backup_db.sh
+pg_restore --list /home/nelluk/polytopia_full_backup.sqlc >/dev/null
+```
+
+Then confirm the exact cluster and service identities:
+
+```bash
+pg_lsclusters
+systemctl show postgresql@18-main.service polytopia.service \
+  -p Id -p ActiveState -p SubState -p MainPID -p NRestarts --no-pager
+sudo ss -ltnp | grep -E ':5432|:5433'
+sudo du -sh /var/lib/postgresql/12/main
+```
+
+Required gate: `18/main` is online on localhost port 5432, `12/main` is down
+on port 5433, nothing listens on 5433, the bot uses the Python 3.12 `.venv`,
+and the new backup plus retained archives validate. Stop on any mismatch.
+
+## C2 — Remove PostgreSQL 12 physical rollback
+
+This is irreversible without restoring an archive. Recheck `pg_lsclusters`
+immediately before running:
+
+```bash
+sudo pg_dropcluster --stop 12 main
+```
+
+Verify that `18/main` remains active on 5432, no 5433 listener exists, and the
+bot PID and restart count remain unchanged. Do not continue if PostgreSQL 18
+or the bot changed state.
+
+## C3 — Remove obsolete PostgreSQL packages
+
+Simulate the exact transaction immediately before approval:
+
+```bash
+sudo apt-get -s remove \
+  postgresql-12 postgresql-client-12 \
+  postgresql-14 postgresql-client-14 \
+  postgresql postgresql-contrib
+```
+
+Proceed only if the simulation removes exactly those six packages and retains
+`postgresql-18`, `postgresql-client-18`, `postgresql-common`,
+`postgresql-client-common`, and `libpq5`:
+
+```bash
+sudo apt-get remove \
+  postgresql-12 postgresql-client-12 \
+  postgresql-14 postgresql-client-14 \
+  postgresql postgresql-contrib
+```
+
+Do not accept an expanded removal transaction and do not run autoremove.
+Afterward, verify installed PostgreSQL packages, `pg_lsclusters`, port 5432,
+and both live services.
+
+## C4 — Remove the Python 3.9 environment
+
+First prove that neither the live process nor effective unit uses it:
+
+```bash
+systemctl show polytopia.service -p MainPID -p ExecStart --no-pager
+readlink -f /proc/$(systemctl show -p MainPID --value polytopia.service)/exe
+/home/nelluk/PolyBot39/.venv/bin/python --version
+sed -n '1,20p' /home/nelluk/PolyBot39/pyvenv.cfg
+```
+
+The executable and `ExecStart` must use Python 3.12 under `.venv`; the
+root-level `pyvenv.cfg` must identify only the old environment. Remove exactly
+these paths:
+
+```bash
+rm -rf -- \
+  /home/nelluk/PolyBot39/bin \
+  /home/nelluk/PolyBot39/include \
+  /home/nelluk/PolyBot39/lib
+rm -- \
+  /home/nelluk/PolyBot39/lib64 \
+  /home/nelluk/PolyBot39/pyvenv.cfg
+```
+
+Never target `/home/nelluk/PolyBot39/.venv`.
+
+## C5 — Tighten configuration permissions
+
+The production service runs as `nelluk`, so restrict the ignored server
+configuration to that account and verify ownership:
+
+```bash
+chmod 0600 /home/nelluk/PolyBot39/server_settings.py
+stat -c '%a %U:%G %n' /home/nelluk/PolyBot39/server_settings.py
+```
+
+## C6 — Final evidence and documentation
+
+Record final clusters, listeners, package versions, effective service unit,
+service PID/restarts, backup validation, and disk usage. Do not restart the bot
+solely for cleanup: the reviewed Python 3.12 drop-in has already survived
+normal starts, and C0 changes no live process. A future normal restart will use
+the canonical `/etc` unit.
+
+After every phase passes, update `docs/POSTGRESQL_UPGRADE_PLAN.md` and
+`docs/PRODUCTION_CUTOVER.md` with actual timestamps, commands, results, disk
+recovery, and the retirement of the old physical/interpreter rollback paths.

--- a/docs/PRODUCTION_CUTOVER.md
+++ b/docs/PRODUCTION_CUTOVER.md
@@ -123,9 +123,15 @@ port values preserve the current local Unix-socket connection. The
 `spreadsheet_creds.json` file must remain present because the production
 Bullet extension stays enabled.
 
-The service drop-in tracked at
-`deploy/systemd/polytopia.service.d/upgrade.conf` adds the explicit production
-profile and changes only the interpreter used by `polytopia.service`.
+During the cutover, the service drop-in then tracked at
+`deploy/systemd/polytopia.service.d/upgrade.conf` added the explicit production
+profile and changed only the interpreter used by `polytopia.service`.
+
+Post-cutover cleanup replaces that temporary override with the complete unit
+tracked at `deploy/systemd/polytopia.service`. The reviewed cleanup procedure
+is in `docs/POST_UPGRADE_CLEANUP.md`. Its current status is **prepared, not
+executed**; the installed drop-in and legacy Python environment remain in
+place until their separately approved host phases pass.
 
 ## Approval gate
 
@@ -382,6 +388,13 @@ requires its own explicit approval.
 Retain the legacy Python 3.9 environment and private cutover archive through a
 settling period. Their later removal is a separately approved cleanup action,
 not part of the cutover.
+
+The later action is prepared in `docs/POST_UPGRADE_CLEANUP.md`. After it is
+executed, this immediate rollback procedure becomes a historical cutover
+record: removing the installed drop-in will no longer select Python 3.9.
+Recovery will instead use the tracked canonical Python 3.12 unit and locked
+environment, with the retained private archive available only for a separately
+reviewed reconstruction.
 
 ## Separately gated API work
 


### PR DESCRIPTION
## What changed

- replace the Python 3.12 cutover drop-in with a complete tracked PolyBot systemd unit
- add a gated, repository-backed PostgreSQL/Python post-upgrade cleanup runbook
- prepare the PostgreSQL and Python cutover records for evidence-backed cleanup close-out

## Why

The live service currently relies on a drop-in while its base unit and enablement link still point to the retained Python 3.9 environment. PostgreSQL 12 and the old Python environment are ready for separately approved cleanup, but the canonical service definition and safety gates must be tracked first.

## Impact

This PR changes repository deployment artifacts and documentation only. It does not install the service unit, reload or restart systemd, access a database, remove packages, or delete either rollback environment.

## Checks

- `systemd-analyze verify deploy/systemd/polytopia.service` passed; the host emitted only an unrelated permission warning for `netplan-ovs-cleanup.service`
- exact service path/directive assertions passed
- `git diff --check` passed
- cleanup worktree is clean
