### PR TITLE
Record post-upgrade cleanup completion

### DIFF
--- a/docs/POSTGRESQL_UPGRADE_PLAN.md
+++ b/docs/POSTGRESQL_UPGRADE_PLAN.md
@@ -420,10 +420,17 @@ Nelluk separately approved the production maintenance window. On 2026-07-29:
   `pg_dump` version 18.4.
 - The root filesystem retained approximately 3.2 GiB free after cutover.
 
-The old PostgreSQL 12 cluster and its packages were intentionally retained.
-Their removal is not part of the cutover approval.
+The old PostgreSQL 12 cluster and its packages were intentionally retained at
+cutover. They were later removed through the separately approved cleanup
+recorded in `docs/POST_UPGRADE_CLEANUP.md`.
 
-## Rollback
+## Historical cutover rollback — retired
+
+The physical PostgreSQL 12 rollback described below was available during the
+cutover and settling period. It was retired on 2026-08-04 when `12/main` and
+the PostgreSQL 12 packages were removed. Do not execute these historical
+steps. Current recovery uses a separately approved PostgreSQL 18 logical
+restore from a validated retained archive.
 
 Copy mode leaves PostgreSQL 12 independent. During the task-disabled canary:
 
@@ -460,30 +467,30 @@ approval.
 - Read-only Discord smoke checks and background tasks pass.
 - PostgreSQL and bot processes remain stable for at least ten minutes.
 - Fresh PostgreSQL 18 backups pass validation.
-- PostgreSQL 12 remains stopped and independently recoverable.
+- PostgreSQL 12 remains stopped and independently recoverable through the
+  settling period, then is removed only through a separately approved cleanup.
 
-## Deferred cleanup
+## Post-upgrade cleanup completed
 
-After at least one to two weeks of stable PostgreSQL 18 operation and multiple
-validated backup cycles, request separate approval to:
+On 2026-08-04, after stable PostgreSQL 18 operation and multiple validated
+backup cycles, the separately approved cleanup completed:
 
-- remove the old PostgreSQL 12 cluster with `pg_dropcluster`;
-- remove unsupported PostgreSQL 12 packages;
-- remove PostgreSQL 14 packages if no longer needed;
-- delete disposable rehearsal artifacts;
-- decide whether to retain or delete the `twospies` database;
-- update monitoring and disk-audit expectations.
+- A fresh full production dump, all seven rotating dumps, and both retained
+  full recovery sets validated before deletion.
+- The stopped 1007 MB PostgreSQL `12/main` cluster was removed with
+  `pg_dropcluster`.
+- PostgreSQL 12 and 14 server/client packages and obsolete metapackages were
+  removed and residual server-package records purged. PostgreSQL 18, shared
+  PostgreSQL packages, and `libpq5` remain installed. No autoremove ran.
+- PostgreSQL 18.4 remained online on localhost-only port 5432 without a
+  restart. All expected database identities and owners remained intact.
+- `twospies`, current rotating backups, the PG4 archive, and the final
+  stopped-service archive were deliberately retained.
+- The generic disk audit required no code change and correctly reported the
+  removed cluster. Free space improved from 1.9 GB to 3.4 GB across the full
+  PostgreSQL/Python cleanup.
 
-Do not combine old-cluster removal with the cutover approval.
-
-The repository-backed cleanup procedure is prepared in
-`docs/POST_UPGRADE_CLEANUP.md`. Its current status is **prepared, not
-executed**. It adds a canonical tracked systemd unit before either rollback
-environment is removed, preserves `twospies` and all current recovery
-archives, and requires a fresh backup plus service/database identity checks
-before the separately approved destructive phases.
-
-When cleanup completes, update this section with the actual evidence and mark
-the PostgreSQL 12 rollback section above as historical. Until then, the old
-cluster remains the stopped physical rollback copy described by the cutover
-record.
+The full commands, gates, hashes, service identities, and retained-artifact
+record are in `docs/POST_UPGRADE_CLEANUP.md`. PostgreSQL recovery now requires
+a separately approved logical restore; the removed physical cluster is no
+longer a rollback option.

--- a/docs/POST_UPGRADE_CLEANUP.md
+++ b/docs/POST_UPGRADE_CLEANUP.md
@@ -1,11 +1,49 @@
 # PostgreSQL 18 and Python 3.12 post-upgrade cleanup
 
-Status: **Prepared; no production cleanup executed by this runbook yet**
+Status: **Complete on 2026-08-04**
 
 This runbook retires the rollback-only PostgreSQL 12 cluster and Python 3.9
 environment after the successful PostgreSQL 18 and Python 3.12 cutovers. Each
 host-changing phase requires Nelluk's explicit approval. Completing one phase
 does not authorize the next phase.
+
+## Completion evidence
+
+- Pull request 138 merged the canonical unit and prepared runbook as
+  `be1f6e8ad6fb8c03917bc45f7bf1919f2417e45c` before host cleanup.
+- `/etc/systemd/system/polytopia.service` matches the tracked unit at SHA-256
+  `9e90b085feaac52c5b75171da6732d9a48ec9b3d64b7287f9ad8cfbbb0bb7c8d`.
+  The enablement link points to that `/etc` unit; the cutover drop-in and
+  non-package-owned `/lib` unit are absent. Installing it did not restart the
+  bot.
+- A fresh mode-0600 full production dump was created at 21:26 EDT and passed
+  `pg_restore --list`. All seven rotating dumps passed the same validation.
+  The PG4 and final stopped-service archives passed every recorded checksum,
+  and their `polytopia2`, `polytopia_dev`, and `twospies` dumps passed restore
+  listing.
+- `12/main`, measured at 1007 MB, was removed with `pg_dropcluster`. The
+  PostgreSQL 12 and 14 server/client packages and old metapackages were
+  removed; the residual server-package records were purged. No autoremove ran.
+- PostgreSQL 18.4 remains the only cluster, online on localhost-only port 5432.
+  `polytopia2`, `polytopia_dev`, and `twospies` retain their expected owners.
+- The five explicit Python 3.9 virtual-environment paths were removed,
+  recovering approximately 473 MB. The active mode-0700 `.venv` remains
+  Python 3.12.13, and the live bot executable resolves to the managed Python
+  3.12.13 interpreter.
+- `server_settings.py`, `config.ini`, and `spreadsheet_creds.json` are all
+  mode 0600 and owned by `nelluk:nelluk`.
+- The bot remained PID 2327849 with `NRestarts=1`; PostgreSQL remained PID
+  1532765 with `NRestarts=0`. Cleanup caused no restart and left no failed
+  systemd units.
+- The final 22:11 EDT disk audit reports 3.4 GB free and 84% use, improved
+  from 1.9 GB free and 91% use before cleanup.
+- Current backups, the PG4 archive, final stopped-service archive, Python
+  cutover archive, `twospies`, application data, configuration, images, and
+  logs were retained.
+- `polyapi.service` remains disabled and inactive. Its legacy Python 3.9
+  command is intentionally unusable after cleanup; enabling the API requires
+  the separately reviewed Python 3.12 service work in
+  `docs/PRODUCTION_CUTOVER.md`.
 
 ## Fixed scope
 
@@ -187,10 +225,10 @@ stat -c '%a %U:%G %n' /home/nelluk/PolyBot39/server_settings.py
 
 Record final clusters, listeners, package versions, effective service unit,
 service PID/restarts, backup validation, and disk usage. Do not restart the bot
-solely for cleanup: the reviewed Python 3.12 drop-in has already survived
-normal starts, and C0 changes no live process. A future normal restart will use
+solely for cleanup: the reviewed Python 3.12 configuration has already survived
+normal starts, and C0 changed no live process. A future normal restart will use
 the canonical `/etc` unit.
 
-After every phase passes, update `docs/POSTGRESQL_UPGRADE_PLAN.md` and
-`docs/PRODUCTION_CUTOVER.md` with actual timestamps, commands, results, disk
-recovery, and the retirement of the old physical/interpreter rollback paths.
+After every phase passed, `docs/POSTGRESQL_UPGRADE_PLAN.md` and
+`docs/PRODUCTION_CUTOVER.md` were updated with the actual results, disk
+recovery, and retirement of the old physical/interpreter rollback paths.

--- a/docs/PRODUCTION_CUTOVER.md
+++ b/docs/PRODUCTION_CUTOVER.md
@@ -20,6 +20,9 @@ it is not standing authorization for a future deployment or rollback.
 - The pre-cutover and stopped-service recovery artifacts are stored in the
   private directory
   `/home/nelluk/backups/polybot-cutover-20260728T173159-0400`.
+- The separately approved post-cutover cleanup completed on 2026-08-04. It
+  installed the complete tracked systemd unit, removed the Python 3.9
+  environment, retained the private archive, and caused no bot restart.
 
 ## Scope and fixed boundaries
 
@@ -33,8 +36,8 @@ it is not standing authorization for a future deployment or rollback.
 - Production Discord bot ID: `484067640302764042`
 - Production image root: `/home/nelluk/PolyBot39/data/images`
 - Production log root: `/home/nelluk/PolyBot39/logs`
-- Legacy interpreter retained for rollback:
-  `/home/nelluk/PolyBot39/bin/python3` (Python 3.9.20)
+- Legacy interpreter retained through the settling period, then retired on
+  2026-08-04: `/home/nelluk/PolyBot39/bin/python3` (Python 3.9.20)
 - New interpreter after sync:
   `/home/nelluk/PolyBot39/.venv/bin/python` (Python 3.12.13)
 
@@ -42,10 +45,10 @@ The PostgreSQL server is not upgraded by this runbook. There is no application
 schema migration and no reason to restore the database during a normal code
 rollback.
 
-`polyapi.service` is disabled and inactive. Keep it inactive during this
-cutover. Its old `uvicorn.workers.UvicornWorker` command is not the reviewed
-Gunicorn 26 configuration, so starting it requires a separate API approval and
-service update.
+`polyapi.service` is disabled and inactive. Keep it inactive. Its old
+Python 3.9 `uvicorn.workers.UvicornWorker` command was never the reviewed
+Gunicorn 26 configuration and is unavailable after post-cutover cleanup, so
+starting it requires a separate API approval and Python 3.12 service update.
 
 ## Reviewed state
 
@@ -129,9 +132,9 @@ profile and changed only the interpreter used by `polytopia.service`.
 
 Post-cutover cleanup replaces that temporary override with the complete unit
 tracked at `deploy/systemd/polytopia.service`. The reviewed cleanup procedure
-is in `docs/POST_UPGRADE_CLEANUP.md`. Its current status is **prepared, not
-executed**; the installed drop-in and legacy Python environment remain in
-place until their separately approved host phases pass.
+is in `docs/POST_UPGRADE_CLEANUP.md`. It completed on 2026-08-04: the complete
+unit is installed under `/etc`, the installed drop-in and non-package-owned
+`/lib` unit are absent, and the legacy Python environment is retired.
 
 ## Approval gate
 
@@ -351,7 +354,13 @@ active, repeatedly restarts, authenticates as the wrong bot, loads an
 unauthorized guild, reports database errors, or cannot load the Bullet
 extension.
 
-## Immediate rollback
+## Historical immediate rollback — retired
+
+The commands below record the rollback that was available during the cutover
+and settling period. They are no longer executable because the Python 3.9
+environment, base `/lib` unit, and cutover drop-in were retired on 2026-08-04.
+Do not run them. Current code recovery must retain the canonical Python 3.12
+unit and rebuild the locked `.venv` if necessary.
 
 Rollback the code and interpreter without restoring PostgreSQL:
 
@@ -385,16 +394,15 @@ A database restore is an exceptional data-recovery action, not a dependency
 rollback step. It would discard legitimate activity after the dump and
 requires its own explicit approval.
 
-Retain the legacy Python 3.9 environment and private cutover archive through a
-settling period. Their later removal is a separately approved cleanup action,
-not part of the cutover.
+The legacy Python 3.9 environment and private cutover archive were retained
+through the settling period. The separately approved cleanup later removed
+only the legacy environment; the private archive remains retained.
 
-The later action is prepared in `docs/POST_UPGRADE_CLEANUP.md`. After it is
-executed, this immediate rollback procedure becomes a historical cutover
-record: removing the installed drop-in will no longer select Python 3.9.
-Recovery will instead use the tracked canonical Python 3.12 unit and locked
-environment, with the retained private archive available only for a separately
-reviewed reconstruction.
+That action is complete and recorded in `docs/POST_UPGRADE_CLEANUP.md`. This
+immediate rollback procedure is now a historical cutover record: removing a
+drop-in cannot select Python 3.9. Recovery instead uses the tracked canonical
+Python 3.12 unit and locked environment, with the retained private archive
+available only for a separately reviewed reconstruction.
 
 ## Separately gated API work
 


### PR DESCRIPTION
## What changed

- record the completed PostgreSQL 18/Python 3.12 post-upgrade cleanup
- mark the PostgreSQL 12 physical rollback and Python 3.9 interpreter rollback as historical and retired
- record backup validation, package removal, retained artifacts, service identities, permissions, and disk recovery
- document the disabled legacy API unit as separately scoped Python 3.12 service work

## Results

- only PostgreSQL 18.4 remains, online on localhost port 5432
- PostgreSQL 12/14 packages and the 1007 MB old cluster are absent
- the canonical `/etc` PolyBot unit matches the tracked file and the bot did not restart
- Python 3.9 environment removed; Python 3.12.13 `.venv` remains active
- fresh and retained backups validated
- root filesystem improved from 1.9 GB free/91% used to 3.4 GB free/84% used

## Checks

- final disk audit reported no failed systemd units
- production bot and PostgreSQL PIDs/restart counts remained stable
- production Git checkout remained clean
- `git diff --check` passed
